### PR TITLE
Update LexiTranslatable.php

### DIFF
--- a/src/Traits/LexiTranslatable.php
+++ b/src/Traits/LexiTranslatable.php
@@ -46,7 +46,7 @@ trait LexiTranslatable
      *  even if service model does not has name and description attributes .
      *
      */
-    public function translate(string $column, ?string $locale = null): string
+    public function translate(string $column, ?string $locale = null): ?string
     {
         $locale = $this->getValidatedLocale($locale);
         $originalText = '';


### PR DESCRIPTION
Fix for the error caused when using the transAttr method on an untranslated field with a null value for $originalText.

Error: App\Models\Example::translate(): Return value must be of type string, null returned